### PR TITLE
Echo the exit status from go test

### DIFF
--- a/main.go
+++ b/main.go
@@ -14,6 +14,7 @@ import (
 	"os"
 	"os/exec"
 	"strings"
+	"syscall"
 
 	"github.com/fatih/color"
 )
@@ -37,7 +38,12 @@ func gotest(args []string) {
 
 	go consume(r)
 
-	cmd.Run()
+	if err := cmd.Run(); err != nil {
+		if ws, ok := cmd.ProcessState.Sys().(syscall.WaitStatus); ok {
+			os.Exit(ws.ExitStatus())
+		}
+		os.Exit(1)
+	}
 }
 
 func consume(r io.Reader) {


### PR DESCRIPTION
This PR adds support for echoing the exit status of `go test` (or simply `1` on error, when status cannot be deduced).

I rely heavily on exit status to know if a command has failed and I think it's a useful metric.

Use case: `while gotest -race ./...; do :; done` (stops on error).

PS. Thanks for this tool, love the colored output!