### PR TITLE
Implemented use of 3 variables instead of a single

### DIFF
--- a/main.go
+++ b/main.go
@@ -21,12 +21,10 @@ import (
 )
 
 var (
-	success = color.New(color.FgGreen)
-	skipped = color.New(color.FgYellow)
-	fail    = color.New(color.FgHiRed)
+	pass = color.New(color.FgGreen)
+	skip = color.New(color.FgYellow)
+	fail = color.New(color.FgHiRed)
 )
-
-const paletteEnv = "GOTEST_PALETTE"
 
 func main() {
 	setPalette()
@@ -86,19 +84,19 @@ func parse(line string) {
 	case strings.HasPrefix(trimmed, "?"):
 		c = nil
 
-	// success
+	// succeeded
 	case strings.HasPrefix(trimmed, "--- PASS"):
 		fallthrough
 	case strings.HasPrefix(trimmed, "ok"):
 		fallthrough
 	case strings.HasPrefix(trimmed, "PASS"):
-		c = success
+		c = pass
 
 	// skipped
 	case strings.HasPrefix(trimmed, "--- SKIP"):
-		c = skipped
+		c = skip
 
-	// failure
+	// failed
 	case strings.HasPrefix(trimmed, "--- FAIL"):
 		fallthrough
 	case strings.HasPrefix(trimmed, "FAIL"):
@@ -127,19 +125,23 @@ func enableOnCI() {
 }
 
 func setPalette() {
-	v := os.Getenv(paletteEnv)
-	if v == "" {
-		return
-	}
-	vals := strings.Split(v, ",")
-	if len(vals) != 2 {
-		return
-	}
-	if c, ok := colors[vals[0]]; ok {
-		fail = color.New(c)
-	}
-	if c, ok := colors[vals[1]]; ok {
-		success = color.New(c)
+	envArray := [3]string{"GOTEST_SKIP_COLOR", "GOTEST_FAIL_COLOR", "GOTEST_PASS_COLOR"}
+
+	for _, e := range envArray {
+		v := os.Getenv(e)
+		if v == "" {
+			continue
+		}
+		if c, ok := colors[v]; ok {
+			switch e {
+			case "GOTEST_FAIL_COLOR":
+				fail = color.New(c)
+			case "GOTEST_PASS_COLOR":
+				pass = color.New(c)
+			case "GOTEST_SKIP_COLOR":
+				skip = color.New(c)
+			}
+		}
 	}
 }
 


### PR DESCRIPTION
Hi @rakyll 

I was pondering about my PR #17 and the fact that I work as a product manager as my day job won. The use-case of the `GOTEST_PALETTE` is not optimal.

So this PR offers an alternative approach. I have however only done the code, not the documentation, but I wanted to now what you think of the approach, before spending too much time on the PR.

The change is splitting the `GOTEST_PALETTE` into 3 separate environment variables and configurable parameters:

- `GOTEST_FAIL_COLOR`
- `GOTEST_PASS_COLOR`
- `GOTEST_SKIP_COLOR`

The last one, where the use-case originates from my PR #17.

You could keep the `GOTEST_PALETTE` for backwards compatibility and even apply PR #17 but I think a split as suggested in this PR is a better approach.

Let me know what you think - and if you wanted to evaluate a documentation update, with the code change please let me know.

As I mentioned in PR #17 I am fairly new to **Go** so if there are code, which could be more idiomatic or something, please let me know.

And I hope it is okay I renamed a few things to keep it more _lean_.