### PR TITLE
Fix GitLab CI detection

### DIFF
--- a/main.go
+++ b/main.go
@@ -115,6 +115,8 @@ func parse(line string) {
 func enableOnCI() {
 	ci := strings.ToLower(os.Getenv("CI"))
 	switch ci {
+	case "true":
+		fallthrough
 	case "travis":
 		fallthrough
 	case "appveyor":


### PR DESCRIPTION
GitLab CI sets `export CI=true`.

See https://docs.gitlab.com/ce/ci/variables/