### PR TITLE
Fix undefined c issue

### DIFF
--- a/main.go
+++ b/main.go
@@ -94,6 +94,8 @@ func consume(wg *sync.WaitGroup, r io.Reader) {
 	}
 }
 
+var c *color.Color
+
 func parse(line string) {
 	trimmed := strings.TrimSpace(line)
 	defer color.Unset()
@@ -152,7 +154,7 @@ func setPalette() {
 		return
 	}
 	if c, ok := colors[vals[0]]; ok {
-		fail = c
+		fail = color.Set(c)
 	}
 	if c, ok := colors[vals[1]]; ok {
 		pass = color.New(c)


### PR DESCRIPTION
PR solving issue https://github.com/rakyll/gotest/issues/27

I figured out that the commits below removed variable `c`, so the error `undefined: c` was continuously generated.
 
https://github.com/rakyll/gotest/commit/cffa99d93a90d58dabed0ba6eae64af1a1b1d0e9
https://github.com/rakyll/gotest/commit/29d015ff1f015bc159b4668edec477e7e8ca9a08

The error
<img width="917" alt="스크린샷 2020-06-08 오전 9 10 27" src="https://user-images.githubusercontent.com/28703198/83983480-c598b100-a969-11ea-9cf9-f76da0ff0a7e.png">


Thus, I added variable `c` and changed `fail = c` to `fail = color.Set(c)` in order to match types

```
func setPalette() {
	v := os.Getenv(paletteEnv)
	if v == "" {
		return
	}
	vals := strings.Split(v, ",")
	if len(vals) != 2 {
		return
	}
	if c, ok := colors[vals[0]]; ok {
		fail = color.Set(c)
	}
	if c, ok := colors[vals[1]]; ok {
		pass = color.New(c)
	}
}
``` 