### PR TITLE
fix data race in sending a signal to the cmd.Process

### DIFF
--- a/main.go
+++ b/main.go
@@ -56,6 +56,11 @@ func gotest(args []string) int {
 	cmd.Stdout = w
 	cmd.Env = os.Environ()
 
+	if err := cmd.Start(); err != nil {
+		log.Print(err)
+		return 1
+	}
+
 	go consume(&wg, r)
 
 	sigc := make(chan os.Signal)
@@ -76,7 +81,7 @@ func gotest(args []string) int {
 		}
 	}()
 
-	if err := cmd.Run(); err != nil {
+	if err := cmd.Wait(); err != nil {
 		if ws, ok := cmd.ProcessState.Sys().(syscall.WaitStatus); ok {
 			return ws.ExitStatus()
 		}


### PR DESCRIPTION
Hello,

In rare cases, I encounter the following error when executing the `gotest` command.
(Similar to https://github.com/rakyll/gotest/issues/31 ? 🤔 )

```bash
panic: runtime error: invalid memory address or nil pointer dereference                                                                                                                                          
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x10a6b7b]                                                                                                                                          
                                                                                                                                                                                                                 
goroutine 17 [running]:                                                                                                                                                                                          
os.(*Process).signal(0x0, 0x110c820, 0x11921a0, 0x0, 0x0)                                                                                                                                                        
        /Users/kei.arima/.anyenv/envs/goenv/versions/1.15.0/src/os/exec_unix.go:65 +0x3b                                                                                                                         
os.(*Process).Signal(...)                                                                                                                                                                                        
        /Users/kei.arima/.anyenv/envs/goenv/versions/1.15.0/src/os/exec.go:131                                                                                                                                   
main.gotest.func2(0xc0000781e0, 0xc000116000, 0xc000078240)                                                                                                                                                      
        /Users/kei.arima/go/pkg/mod/github.com/rakyll/gotest@v0.0.5/main.go:72 +0x5d                                                                                                                             
created by main.gotest                                                                                                                                                                                           
        /Users/kei.arima/go/pkg/mod/github.com/rakyll/gotest@v0.0.5/main.go:68 +0x42d                                                                                                                            
make: *** [test] Error 2
```

On `main.go:L72`, There is a data race in the reference to the `cmd.Process` by the goroutine that seems to be making the results unstable. 
https://github.com/rakyll/gotest/blob/v0.0.5/main.go#L72

Because the `cmd.Process` field is set by `cmd.Run()` on `main.go:L79`.
https://github.com/rakyll/gotest/blob/v0.0.5/main.go#L79

In this PR, I propose to resolve this data race by using `cmd.Start()` and `cmd.Wait()` instead of the `cmd.Run()` 
