### PR TITLE
feat: Show colorized diff

### DIFF
--- a/main.go
+++ b/main.go
@@ -22,9 +22,11 @@ import (
 )
 
 var (
-	pass = color.FgGreen
-	skip = color.FgYellow
-	fail = color.FgHiRed
+	pass     = color.FgGreen
+	skip     = color.FgYellow
+	fail     = color.FgHiRed
+	expected = color.FgHiRed
+	actual   = color.FgGreen
 
 	skipnotest bool
 )
@@ -133,6 +135,12 @@ func parse(line string) {
 		fallthrough
 	case strings.HasPrefix(trimmed, "FAIL"):
 		c = fail
+	// expected
+	case strings.HasPrefix(trimmed, "- "):
+		c = expected
+	// actual
+	case strings.HasPrefix(trimmed, "+ "):
+		c = actual
 	}
 
 	color.Set(c)


### PR DESCRIPTION
This makes errors more identifiable. 

It is useful when there is diff from some tools like [google/go-cmp](https://github.com/google/go-cmp).
 


![image](https://user-images.githubusercontent.com/12907474/117900864-13016900-b305-11eb-86d2-1bcb7bba5943.png)
