### PR TITLE
Fix deadlock on err

### DIFF
--- a/main.go
+++ b/main.go
@@ -58,6 +58,7 @@ func gotest(args []string) int {
 
 	if err := cmd.Start(); err != nil {
 		log.Print(err)
+		wg.Done()
 		return 1
 	}
 


### PR DESCRIPTION
This fixes a bug where the program failed to end properly,
if `cmd.Start()` returned an error. The reason is, that it
waited infinitely on the waitgroup in the deferred wg.Wait().