### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ $ curl https://gotest-release.s3.amazonaws.com/gotest_linux > gotest && chmod +x
 Alternatively:
 
 ```
-$ go get -u github.com/rakyll/gotest
+$ go install github.com/rakyll/gotest
 ```
 
 # Usage


### PR DESCRIPTION
https://go.dev/doc/go-get-install-deprecation

> Starting in Go 1.17, installing executables with go get is deprecated. go install may be used instead.

Using `go get` leads to `Command 'gotest' not found, ...`